### PR TITLE
Add empty `fpi_device_cros_fp_init()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@
 
 </div>
 
+## Developing Fingerprint Driver for Chromebooks
+### Setup
+Install meson and some dependencies. Run
+```bash
+meson setup \
+  --prefix        /usr \
+  --libexecdir    lib \
+  --sbindir       bin \
+  --buildtype     plain \
+  --auto-features enabled \
+  --wrap-mode     nodownload
+mesonbuild
+cd mesonbuild
+```
+### Install
+```
+# In `mesonbuild`
+sudo meson install
+```
+
 ## History
 
 **LibFPrint** was originally developed as part of an

--- a/libfprint/drivers/cros_fp.c
+++ b/libfprint/drivers/cros_fp.c
@@ -38,6 +38,11 @@ static const FpIdEntry id_table[] = {
 };
 
 static void
+fpi_device_cros_fp_init(FpiDeviceCrosFp *klass)
+{
+}
+
+static void
 fpi_device_cros_fp_class_init (FpiDeviceCrosFpClass *klass)
 {
   FpDeviceClass *dev_class = FP_DEVICE_CLASS (klass);


### PR DESCRIPTION
Without it `meson build` fails.